### PR TITLE
Add -bs-D BSB_BACKEND to bsc call

### DIFF
--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -170,6 +170,14 @@ let output_ninja_and_namespace_map
     in 
     if bs_suffix then Ext_string.inter2 "-bs-suffix" result else result
   in 
+  let bsc_flags =
+    Printf.sprintf
+      "-bs-D BSB_BACKEND=\"%s\" %s"
+      (match backend with
+      | Bsb_config_types.Js -> "js"
+      | Bsb_config_types.Bytecode -> "bytecode"
+      | Bsb_config_types.Native -> "native")
+      bsc_flags in
 
   let warnings = Bsb_warning.opt_warning_to_string not_dev warning in
 

--- a/lib/bsb.ml
+++ b/lib/bsb.ml
@@ -17581,6 +17581,14 @@ let output_ninja_and_namespace_map
     in 
     if bs_suffix then Ext_string.inter2 "-bs-suffix" result else result
   in 
+  let bsc_flags =
+    Printf.sprintf
+      "-bs-D BSB_BACKEND=\"%s\" %s"
+      (match backend with
+      | Bsb_config_types.Js -> "js"
+      | Bsb_config_types.Bytecode -> "bytecode"
+      | Bsb_config_types.Native -> "native")
+      bsc_flags in
 
   let warnings = Bsb_warning.opt_warning_to_string not_dev warning in
 


### PR DESCRIPTION
This allows you to do things like this!

```ocaml
#if BSB_BACKEND = "native" then
  print_endline "Hello native"
#elif BSB_BACKEND = "bytecode" then
  print_endline "Hello bytecode"
#elif BSB_BACKEND = "js" then
  print_endline "Hello js"
#end
```