### PR TITLE
Slightly simplify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Bsb-native is a fork of [bsb](https://bucklescript.github.io/docs/en/build-overv
 
 ## Install
 
-1) Add `"bs-platform": "bsansouci/bsb-native#3.2.0"` as a devDependency to your `package.json`
+1) Run `npm install --save-dev bsb-native` / `yarn add --dev bsb-native`.
 2) Add a `bsconfig.json` like you would for bsb. Bsb-native uses the same schema, located [here](http://bucklescript.github.io/bucklescript/docson/#build-schema.json) with small additions like `entries` (see below for complete config schema).
-3) run `npm install` / `yarn`.
 
 An [example bsconfig.json](https://github.com/bsansouci/bsb-native-example/blob/master/bsconfig.json):
 ```js


### PR DESCRIPTION
Now that the dependency isn't based on a git repository, we can simply install through just the package name. I added both npm and yarn install instructions.